### PR TITLE
[PR] feat(automation): add automated weekly & monthly scheduled reports via Telegram

### DIFF
--- a/Expense Tracking_v1.json
+++ b/Expense Tracking_v1.json
@@ -11,7 +11,7 @@
       "type": "n8n-nodes-base.telegramTrigger",
       "typeVersion": 1.2,
       "position": [
-        -1888,
+        -2240,
         -128
       ],
       "id": "673262b4-0c1d-4aa0-a625-8fde08ce71f0",
@@ -60,7 +60,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.3,
       "position": [
-        -992,
+        -1344,
         64
       ],
       "id": "ef3527e3-d124-4005-aadf-f5e5789331f0",
@@ -95,7 +95,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.3,
       "position": [
-        -768,
+        -1120,
         160
       ],
       "id": "8eae1d71-57c5-4ffe-843e-c2837eae5c36",
@@ -142,7 +142,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -1664,
+        -2016,
         -128
       ],
       "id": "b2c455d3-3930-47e1-9875-0d1d49dfd8f3",
@@ -157,7 +157,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        -544,
+        -896,
         64
       ],
       "id": "05dc8d26-8e96-4795-adfa-e48b85cd78d9",
@@ -259,7 +259,7 @@
       "type": "n8n-nodes-base.googleSheets",
       "typeVersion": 4.7,
       "position": [
-        576,
+        224,
         160
       ],
       "id": "d70e9192-4d09-4950-aa2f-2ab62ea0e71d",
@@ -300,7 +300,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        352,
+        0,
         160
       ],
       "id": "2ff26a40-bc43-447a-b456-79f530bfa5b6",
@@ -338,7 +338,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.4,
       "position": [
-        -320,
+        -672,
         64
       ],
       "id": "34f721c1-9cda-44e6-a640-56ee4736095a",
@@ -361,7 +361,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -96,
+        -448,
         64
       ],
       "id": "b2e7e668-d863-4605-b4d0-487921c7d4cf",
@@ -384,7 +384,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -96,
+        -448,
         256
       ],
       "id": "458ced93-f181-4353-a7ba-f6822df1d43a",
@@ -419,7 +419,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.4,
       "position": [
-        128,
+        -224,
         160
       ],
       "id": "ea9fa4ec-6de6-405d-8950-20d650b26075",
@@ -432,7 +432,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -544,
+        -896,
         -128
       ],
       "id": "340912f4-08bc-43d2-a923-b0407af267be",
@@ -445,7 +445,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -320,
+        -672,
         -128
       ],
       "id": "0de08a65-4c0b-40d4-a749-3fcdd9b2b900",
@@ -460,7 +460,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        128,
+        -224,
         -128
       ],
       "id": "ddba5f3f-272c-4ae4-9c1a-0f4e3de68c2b",
@@ -500,7 +500,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.3,
       "position": [
-        -1216,
+        -1568,
         -32
       ],
       "id": "197204c6-f01e-435e-b6b3-f10b142f98c2",
@@ -513,7 +513,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -992,
+        -1344,
         -320
       ],
       "id": "3afa7384-4a9a-4529-bc61-0bbdb94e5a84",
@@ -526,7 +526,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -544,
+        -896,
         -320
       ],
       "id": "6c41394f-afbe-4f58-a90d-19279d04ad7c",
@@ -540,7 +540,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -320,
+        -672,
         -320
       ],
       "id": "b0801d78-124b-482f-8a9f-75bc84e37deb",
@@ -555,7 +555,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        128,
+        -224,
         -320
       ],
       "id": "3cd701e4-9ce8-4338-8940-12a7cb974b91",
@@ -595,7 +595,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.3,
       "position": [
-        -1440,
+        -1792,
         -128
       ],
       "id": "9d985f7f-2d96-4786-b618-00f8b164cead",
@@ -619,7 +619,7 @@
       "type": "n8n-nodes-base.googleSheets",
       "typeVersion": 4.7,
       "position": [
-        -1216,
+        -1568,
         -512
       ],
       "id": "f3379dc9-ef3b-4b0a-a635-45ba1f1479e1",
@@ -650,7 +650,7 @@
       "type": "n8n-nodes-base.googleSheets",
       "typeVersion": 4.7,
       "position": [
-        -768,
+        -1120,
         -320
       ],
       "id": "1831c031-21f5-4a55-89ab-e0607778b84c",
@@ -681,7 +681,7 @@
       "type": "n8n-nodes-base.googleSheets",
       "typeVersion": 4.7,
       "position": [
-        -768,
+        -1120,
         -128
       ],
       "id": "3b3a9e5f-d9fb-4bf2-80c2-504cc691227d",
@@ -700,7 +700,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        -992,
+        -1344,
         -512
       ],
       "id": "660f1963-8d01-4948-91f0-85dcefb7fc08",
@@ -715,7 +715,7 @@
       "type": "n8n-nodes-base.telegram",
       "typeVersion": 1.2,
       "position": [
-        -544,
+        -896,
         -512
       ],
       "id": "6b74334e-c59e-44fc-94f1-cd851d9fabcf",
@@ -745,7 +745,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -768,
+        -1120,
         -512
       ],
       "id": "0281f2f4-b5d3-4dac-b907-61a2f1457771",
@@ -768,7 +768,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -96,
+        -448,
         -128
       ],
       "id": "2898196a-d8a6-4eb3-ab2b-e873b996431e",
@@ -791,11 +791,392 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -96,
+        -448,
         -320
       ],
       "id": "03779857-e271-440f-bf68-00ca2258f2d6",
       "name": "Build reply text2"
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "weeks"
+            }
+          ]
+        }
+      },
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [
+        -2240,
+        480
+      ],
+      "id": "4b3478fc-9d4e-4719-822d-9c1ea2493b57",
+      "name": "Schedule Trigger"
+    },
+    {
+      "parameters": {
+        "authentication": "serviceAccount",
+        "documentId": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?usp=sharing",
+          "mode": "url"
+        },
+        "sheetName": {
+          "__rl": true,
+          "mode": "url",
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?gid=0#gid=0",
+          "__regex": "https:\\/\\/docs\\.google\\.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        -1568,
+        480
+      ],
+      "id": "0d88838f-9ce7-478d-ac24-b5e3f28c6e9c",
+      "name": "Get Transactions rows2",
+      "credentials": {
+        "googleApi": {
+          "id": "s0r8f5SwaYDX6QK7",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Server is UTC. +8 = PHT.\nconst now = new Date(new Date().getTime() + 8 * 60 * 60 * 1000);\n\nfunction toDateStr(d) {\n  const y = d.getUTCFullYear();\n  const m = String(d.getUTCMonth() + 1).padStart(2, '0');\n  const dd = String(d.getUTCDate()).padStart(2, '0');\n  return `${y}-${m}-${dd}`;\n}\n\n// Last Sunday → today (this Sunday)\nconst dow = now.getUTCDay(); // 0 = Sunday in PHT\nconst lastSunday = new Date(now);\nlastSunday.setUTCDate(now.getUTCDate() - dow - 7);\n\nreturn [{\n  json: {\n    ...$json,\n    report_start: toDateStr(lastSunday),\n    report_end:   toDateStr(now),\n    reportType:   \"weekly\",\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1792,
+        480
+      ],
+      "id": "ad5ff02d-c18a-4212-a291-7ef4dae7c4f7",
+      "name": "Filter rows to period"
+    },
+    {
+      "parameters": {
+        "jsCode": "const rows = items.map(i => i.json).filter(r => !r._no_rows);\n\nconst wantCategories = new Set([\"miscellaneous\", \"self-care\"]);\nconst expenseTotals = {};\nconst incomeTotals = {};\n\nlet totalExpense = 0;\nlet totalIncome = 0;\nlet needs = 0;\nlet wants = 0;\n\nfor (const r of rows) {\n  const type = String(r.Type || \"\").toLowerCase();\n  const cat = String(r.Category || \"\").toLowerCase();\n  const amt = Number(r.Amount || 0);\n\n  if (type === \"income\") {\n    incomeTotals[cat] = (incomeTotals[cat] || 0) + amt;\n    totalIncome += amt;\n  } else {\n    expenseTotals[cat] = (expenseTotals[cat] || 0) + amt;\n    totalExpense += amt;\n\n    if (wantCategories.has(cat)) wants += amt;\n    else needs += amt;\n  }\n}\n\nconst needsPct = totalExpense ? (needs / totalExpense) * 100 : 0;\nconst wantsPct = totalExpense ? (wants / totalExpense) * 100 : 0;\n\nconst meta = items[0]?.json || {};\n\nreturn [{\n  json: {\n    reportType: meta.reportType || \"weekly\",\n    report_start: meta.report_start || \"\",\n    report_end: meta.report_end || \"\",\n    totalExpense,\n    totalIncome,\n    needs,\n    wants,\n    needsPct,\n    wantsPct,\n    expenseTotals,\n    incomeTotals,\n    tx_count: rows.length,\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1120,
+        480
+      ],
+      "id": "2215935e-e75d-4d28-98ef-fa29152cfe78",
+      "name": "Aggregate totals"
+    },
+    {
+      "parameters": {
+        "authentication": "serviceAccount",
+        "documentId": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?usp=sharing",
+          "mode": "url"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?gid=449480570#gid=449480570",
+          "mode": "url"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        -896,
+        480
+      ],
+      "id": "4b82d75f-1f35-4488-969e-c1c634473b64",
+      "name": "Get Payments rows1",
+      "credentials": {
+        "googleApi": {
+          "id": "s0r8f5SwaYDX6QK7",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const rows = items.map(i => i.json);\n\n// Pull summary from upstream Aggregate totals node\nconst summary = $('Aggregate totals').first().json;\n\nconst normSource = (s) => String(s ?? '').trim() || 'Unknown';\nconst toNumber = (v) => {\n  const n = Number(String(v ?? '').replace(/,/g, '').trim());\n  return Number.isFinite(n) ? n : 0;\n};\n\nconst balances = {};\nlet total = 0;\n\nfor (const r of rows) {\n  const source = normSource(r.Source);\n  const amt = toNumber(r.Amount);\n  balances[source] = (balances[source] || 0) + amt;\n  total += amt;\n}\n\nconst breakdown = Object.entries(balances)\n  .map(([source, amount]) => ({ source, amount }))\n  .sort((a, b) => b.amount - a.amount);\n\nreturn [{\n  json: {\n    // Pass-through summary fields from Aggregate totals\n    reportType: summary.reportType,\n    report_start: summary.report_start,\n    report_end: summary.report_end,\n    totalExpense: summary.totalExpense,\n    totalIncome: summary.totalIncome,\n    needs: summary.needs,\n    wants: summary.wants,\n    needsPct: summary.needsPct,\n    wantsPct: summary.wantsPct,\n    expenseTotals: summary.expenseTotals,\n    incomeTotals: summary.incomeTotals,\n    // Balance fields\n    breakdown,\n    total,\n    count: rows.length,\n    no_rows: rows.length === 0,\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -672,
+        480
+      ],
+      "id": "e50aa0d2-a64e-427c-8e52-7a6ede7a1049",
+      "name": "Aggregate balances1"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "28897132-397b-4dbd-8b15-cd63e0f3a7cd",
+              "name": "=reply_text",
+              "value": "={{ \n`📊 Automated ${($json.reportType || \"weekly\").toUpperCase()} Report\nPeriod: ${($json.report_start || \"\").slice(0,10)} → ${($json.report_end || \"\").slice(0,10)}\n\n💸 Total Expenses: ₱${Number($json.totalExpense || 0).toFixed(2)}\n💰 Total Income: ₱${Number($json.totalIncome || 0).toFixed(2)}\n🧺 Needs: ₱${Number($json.needs || 0).toFixed(2)} (${Number($json.needsPct || 0).toFixed(1)}%)\n🎉 Wants: ₱${Number($json.wants || 0).toFixed(2)} (${Number($json.wantsPct || 0).toFixed(1)}%)\n\n📌 Expense by category:\n${\n  Object.entries($json.expenseTotals || {})\n    .sort((a,b)=>b[1]-a[1])\n    .map(([k,v])=>`- ${k}: ₱${Number(v).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n📌 Income by category:\n${\n  Object.entries($json.incomeTotals || {})\n    .sort((a,b)=>b[1]-a[1])\n    .map(([k,v])=>`- ${k}: ₱${Number(v).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n💳 Current balance by source:\n${\n  ($json.breakdown || [])\n    .map(x => `- ${x.source}: ₱${Number(x.amount || 0).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n--------------------\nTotal balance: ₱${Number($json.total || 0).toFixed(2)}\n`\n}}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -448,
+        480
+      ],
+      "id": "a6287dd9-3387-4c9d-b5b9-c7bb43366f6f",
+      "name": "Build final report text"
+    },
+    {
+      "parameters": {
+        "chatId": "=1505475835",
+        "text": "={{ $json.reply_text }}",
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        -224,
+        480
+      ],
+      "id": "1dc0150c-e907-4948-9a93-2b6140662095",
+      "name": "Send a text message1",
+      "webhookId": "b31acdeb-c0fe-4e5a-b9a4-d0d7dc40fdef",
+      "credentials": {
+        "telegramApi": {
+          "id": "5MkzmwDMblVJ4vqP",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Always weekly only\nreturn [{\n  json: {\n    report_type: \"weekly\",\n    run_date: new Date().toISOString(),\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -2016,
+        480
+      ],
+      "id": "4466eb30-c627-45db-aeec-9cc58f40d85c",
+      "name": "Set report type"
+    },
+    {
+      "parameters": {
+        "jsCode": "const meta = $('Filter rows to period').item.json;\n\nconst startStr = meta.report_start; // \"YYYY-MM-DD\"\nconst endStr   = meta.report_end;   // \"YYYY-MM-DD\"\n\nconst filtered = items\n  .map(i => i.json)\n  .filter(r => {\n    // Compare just the date portion (first 10 chars) as a string\n    const d = String(r.Date || \"\").slice(0, 10);\n    return d >= startStr && d <= endStr;\n  })\n  .map(r => ({\n    json: {\n      ...r,\n      reportType: meta.reportType,\n      report_start: meta.report_start,\n      report_end: meta.report_end,\n    }\n  }));\n\nif (filtered.length === 0) {\n  return [{\n    json: {\n      _no_rows: true,\n      reportType: meta.reportType,\n      report_start: meta.report_start,\n      report_end: meta.report_end,\n      Date: meta.report_start,\n      Type: \"\", Category: \"\", Amount: 0, Description: \"\", Source: \"\",\n    }\n  }];\n}\n\nreturn filtered;\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1344,
+        480
+      ],
+      "id": "efbf4270-ec29-4f06-9e69-2d445e95fafd",
+      "name": "Filter transactions for period"
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "months",
+              "triggerAtDayOfMonth": 28
+            }
+          ]
+        }
+      },
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [
+        -2240,
+        704
+      ],
+      "id": "883d763e-69e9-4b2b-9f6f-bbacdfc06d2c",
+      "name": "Schedule Trigger1"
+    },
+    {
+      "parameters": {
+        "authentication": "serviceAccount",
+        "documentId": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?usp=sharing",
+          "mode": "url"
+        },
+        "sheetName": {
+          "__rl": true,
+          "mode": "url",
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?gid=0#gid=0",
+          "__regex": "https:\\/\\/docs\\.google\\.com\\/spreadsheets\\/d\\/[0-9a-zA-Z\\-_]+.*\\#gid=([0-9]+)"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        -1568,
+        704
+      ],
+      "id": "511ea81f-65bc-467d-955a-c15185bdca26",
+      "name": "Get Transactions rows3",
+      "credentials": {
+        "googleApi": {
+          "id": "s0r8f5SwaYDX6QK7",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const now = new Date(new Date().getTime() + 8 * 60 * 60 * 1000);\n\nfunction toDateStr(d) {\n  const y = d.getUTCFullYear();\n  const m = String(d.getUTCMonth() + 1).padStart(2, '0');\n  const dd = String(d.getUTCDate()).padStart(2, '0');\n  return `${y}-${m}-${dd}`;\n}\n\n// today = the 28th (current month)\nconst endDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 28));\n\n// start = 28th of last month\nconst startDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - 1, 28));\n\nreturn [{\n  json: {\n    ...$json,\n    report_start: toDateStr(startDay),  // e.g. 2026-01-28\n    report_end:   toDateStr(endDay),    // e.g. 2026-02-28\n    reportType:   \"monthly\",\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1792,
+        704
+      ],
+      "id": "b4c199c3-541b-48ed-a21c-17b4df1cef9a",
+      "name": "Filter rows to period1"
+    },
+    {
+      "parameters": {
+        "jsCode": "const rows = items.map(i => i.json).filter(r => !r._no_rows);\n\nconst wantCategories = new Set([\"miscellaneous\", \"self-care\"]);\nconst expenseTotals = {};\nconst incomeTotals = {};\n\nlet totalExpense = 0, totalIncome = 0, needs = 0, wants = 0;\n\nfor (const r of rows) {\n  const type = String(r.Type || \"\").toLowerCase();\n  const cat  = String(r.Category || \"\").toLowerCase();\n  const amt  = Number(r.Amount || 0);\n\n  if (type === \"income\") {\n    incomeTotals[cat] = (incomeTotals[cat] || 0) + amt;\n    totalIncome += amt;\n  } else {\n    expenseTotals[cat] = (expenseTotals[cat] || 0) + amt;\n    totalExpense += amt;\n    if (wantCategories.has(cat)) wants += amt;\n    else needs += amt;\n  }\n}\n\nconst meta = items[0]?.json || {};\n\nreturn [{\n  json: {\n    reportType:   meta.reportType || \"monthly\",\n    report_start: meta.report_start || \"\",\n    report_end:   meta.report_end || \"\",\n    totalExpense, totalIncome,\n    needs, wants,\n    needsPct: totalExpense ? (needs / totalExpense) * 100 : 0,\n    wantsPct: totalExpense ? (wants / totalExpense) * 100 : 0,\n    expenseTotals, incomeTotals,\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1120,
+        704
+      ],
+      "id": "eaf82e46-6d61-426f-9cda-d1f06dc63cff",
+      "name": "Aggregate totals1"
+    },
+    {
+      "parameters": {
+        "authentication": "serviceAccount",
+        "documentId": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?usp=sharing",
+          "mode": "url"
+        },
+        "sheetName": {
+          "__rl": true,
+          "value": "https://docs.google.com/spreadsheets/d/1AWNo7ZgwmQKCPXKoFPE-jMRbgh1vnZl_nHBw7RIulTQ/edit?gid=449480570#gid=449480570",
+          "mode": "url"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.googleSheets",
+      "typeVersion": 4.7,
+      "position": [
+        -896,
+        704
+      ],
+      "id": "d6cd6e2e-2fb9-49d3-aa46-d88fb3ec1aef",
+      "name": "Get Payments rows2",
+      "credentials": {
+        "googleApi": {
+          "id": "s0r8f5SwaYDX6QK7",
+          "name": "Google Sheets account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const rows = items.map(i => i.json);\nconst summary = $('Aggregate totals1').first().json;\n\nconst normSource = (s) => String(s ?? '').trim() || 'Unknown';\nconst toNumber = (v) => {\n  const n = Number(String(v ?? '').replace(/,/g, '').trim());\n  return Number.isFinite(n) ? n : 0;\n};\n\nconst balances = {};\nlet total = 0;\n\nfor (const r of rows) {\n  const source = normSource(r.Source);\n  const amt = toNumber(r.Amount);\n  balances[source] = (balances[source] || 0) + amt;\n  total += amt;\n}\n\nconst breakdown = Object.entries(balances)\n  .map(([source, amount]) => ({ source, amount }))\n  .sort((a, b) => b.amount - a.amount);\n\nreturn [{\n  json: {\n    reportType:    summary.reportType,\n    report_start:  summary.report_start,\n    report_end:    summary.report_end,\n    totalExpense:  summary.totalExpense,\n    totalIncome:   summary.totalIncome,\n    needs:         summary.needs,\n    wants:         summary.wants,\n    needsPct:      summary.needsPct,\n    wantsPct:      summary.wantsPct,\n    expenseTotals: summary.expenseTotals,\n    incomeTotals:  summary.incomeTotals,\n    breakdown, total,\n    no_rows: rows.length === 0,\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -672,
+        704
+      ],
+      "id": "a94b304a-89f3-4d3a-aa18-1c1dae37a9c5",
+      "name": "Aggregate balances2"
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "28897132-397b-4dbd-8b15-cd63e0f3a7cd",
+              "name": "=reply_text",
+              "value": "={{ \n`📊 Automated MONTHLY Report\nPeriod: ${($json.report_start || \"\").slice(0,10)} → ${($json.report_end || \"\").slice(0,10)}\n\n💸 Total Expenses: ₱${Number($json.totalExpense || 0).toFixed(2)}\n💰 Total Income: ₱${Number($json.totalIncome || 0).toFixed(2)}\n🧺 Needs: ₱${Number($json.needs || 0).toFixed(2)} (${Number($json.needsPct || 0).toFixed(1)}%)\n🎉 Wants: ₱${Number($json.wants || 0).toFixed(2)} (${Number($json.wantsPct || 0).toFixed(1)}%)\n\n📌 Expense by category:\n${\n  Object.entries($json.expenseTotals || {})\n    .sort((a,b)=>b[1]-a[1])\n    .map(([k,v])=>`- ${k}: ₱${Number(v).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n📌 Income by category:\n${\n  Object.entries($json.incomeTotals || {})\n    .sort((a,b)=>b[1]-a[1])\n    .map(([k,v])=>`- ${k}: ₱${Number(v).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n💳 Current balance by source:\n${\n  ($json.breakdown || [])\n    .map(x => `- ${x.source}: ₱${Number(x.amount || 0).toFixed(2)}`)\n    .join(\"\\n\") || \"- none\"\n}\n\n--------------------\nTotal balance: ₱${Number($json.total || 0).toFixed(2)}\n`\n}}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        -448,
+        704
+      ],
+      "id": "108064f8-0f0d-44cb-b805-1ecfc3039464",
+      "name": "Build final report text1"
+    },
+    {
+      "parameters": {
+        "chatId": "=1505475835",
+        "text": "={{ $json.reply_text }}",
+        "additionalFields": {}
+      },
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1.2,
+      "position": [
+        -224,
+        704
+      ],
+      "id": "0dd3d88b-f15d-41e5-8cf1-f3eb44db86e2",
+      "name": "Send a text message2",
+      "webhookId": "b31acdeb-c0fe-4e5a-b9a4-d0d7dc40fdef",
+      "credentials": {
+        "telegramApi": {
+          "id": "5MkzmwDMblVJ4vqP",
+          "name": "Telegram account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "return [{\n  json: {\n    report_type: \"monthly\",\n    run_date: new Date().toISOString(),\n  }\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -2016,
+        704
+      ],
+      "id": "662f5b93-68fc-4f39-b5fc-bd65e93d6e20",
+      "name": "Set report type1"
+    },
+    {
+      "parameters": {
+        "jsCode": "const meta = $('Filter rows to period1').item.json;\n\nconst startStr = meta.report_start;\nconst endStr   = meta.report_end;\n\nconst filtered = items\n  .map(i => i.json)\n  .filter(r => {\n    const d = String(r.Date || \"\").slice(0, 10);\n    return d >= startStr && d <= endStr;\n  })\n  .map(r => ({\n    json: {\n      ...r,\n      reportType: meta.reportType,\n      report_start: meta.report_start,\n      report_end: meta.report_end,\n    }\n  }));\n\nif (filtered.length === 0) {\n  return [{\n    json: {\n      _no_rows: true,\n      reportType: meta.reportType,\n      report_start: meta.report_start,\n      report_end: meta.report_end,\n      Date: meta.report_start,\n      Type: \"\", Category: \"\", Amount: 0, Description: \"\", Source: \"\",\n    }\n  }];\n}\n\nreturn filtered;\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        -1344,
+        704
+      ],
+      "id": "b9bc18e0-32ab-4c8f-840d-6f2e7c8f0c09",
+      "name": "Filter transactions for period1"
     }
   ],
   "pinData": {},
@@ -1091,6 +1472,204 @@
           }
         ]
       ]
+    },
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Set report type",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Transactions rows2": {
+      "main": [
+        [
+          {
+            "node": "Filter transactions for period",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter rows to period": {
+      "main": [
+        [
+          {
+            "node": "Get Transactions rows2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Payments rows1": {
+      "main": [
+        [
+          {
+            "node": "Aggregate balances1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate totals": {
+      "main": [
+        [
+          {
+            "node": "Get Payments rows1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate balances1": {
+      "main": [
+        [
+          {
+            "node": "Build final report text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build final report text": {
+      "main": [
+        [
+          {
+            "node": "Send a text message1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set report type": {
+      "main": [
+        [
+          {
+            "node": "Filter rows to period",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter transactions for period": {
+      "main": [
+        [
+          {
+            "node": "Aggregate totals",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Schedule Trigger1": {
+      "main": [
+        [
+          {
+            "node": "Set report type1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Transactions rows3": {
+      "main": [
+        [
+          {
+            "node": "Filter transactions for period1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter rows to period1": {
+      "main": [
+        [
+          {
+            "node": "Get Transactions rows3",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate totals1": {
+      "main": [
+        [
+          {
+            "node": "Get Payments rows2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Payments rows2": {
+      "main": [
+        [
+          {
+            "node": "Aggregate balances2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate balances2": {
+      "main": [
+        [
+          {
+            "node": "Build final report text1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build final report text1": {
+      "main": [
+        [
+          {
+            "node": "Send a text message2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set report type1": {
+      "main": [
+        [
+          {
+            "node": "Filter rows to period1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter transactions for period1": {
+      "main": [
+        [
+          {
+            "node": "Aggregate totals1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
     }
   },
   "active": true,
@@ -1099,7 +1678,7 @@
     "binaryMode": "separate",
     "availableInMCP": false
   },
-  "versionId": "88515bd8-2ead-457b-bc29-e0eb134149fe",
+  "versionId": "10652261-a74e-4b20-b662-352ece27a340",
   "meta": {
     "templateCredsSetupCompleted": true,
     "instanceId": "48936346723d79e4f25d7d91cbcadb629760e9475e677dadb70ec847181259a9"


### PR DESCRIPTION
## 2026-03-01

### Features
- **Automated Weekly Report**: New scheduled workflow that fires every Sunday at 8:00 AM PHT (Saturday 23:00 UTC), sending a full financial summary to Telegram including total expenses, total income, needs/wants breakdown, expense & income by category, current balance by source, and total balance.
- **Automated Monthly Report**: New standalone workflow that fires on the 28th of every month, covering the period from the 28th of the previous month to the 28th of the current month, with the same full report structure as the weekly report.

### Bug Fixes
- **Fixed node execution order**: `Filter rows to period` was wired after `Filter transactions for period`, causing the date range to be undefined at filtering time. Corrected the connection chain so the date range is computed first.
- **Fixed ₱0.00 report values**: `Aggregate balances1` was discarding all summary fields (expenses, income, needs, wants) from `Aggregate totals`. Now passes all fields through to `Build final report text`.
- **Fixed blank Period line**: `Build final report text` was referencing `reportStart`/`reportEnd` (camelCase) instead of the actual field names `report_start`/`report_end` (snake_case).
- **Fixed wrong trigger day**: Weekly Schedule Trigger was set to Saturday — updated to Saturday 23:00 UTC which correctly maps to Sunday 07:00 AM PHT.
- **Fixed timezone shift bug**: Date calculations using local `getDate()`/`setHours()` were shifting dates by −8 hours when serialized via `.toISOString()`. Replaced with a manual UTC+8 offset approach using plain `YYYY-MM-DD` string comparisons to fully eliminate timezone issues.
- **Fixed weekly period spanning 2 weeks**: End date was set to next Monday; corrected to today (Sunday, the report day).
- **Fixed week start day**: Changed from Monday-based to Sunday-based week calculation.
- **Removed stray 59-second debug interval** from Schedule Trigger that would have spammed reports every minute in production.

### Refactoring
- Extracted monthly report logic into its own dedicated workflow, keeping the weekly workflow clean and focused.
- Simplified `Set report type` node — weekly workflow now always outputs `report_type: "weekly"` with no conditional branching.
- Replaced complex `Date` object UTC gymnastics with straightforward `YYYY-MM-DD` string slicing for date range filtering — simpler, timezone-safe, and easier to debug.
